### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/content/docs/main/explanations/how-maintenance-works/_index.md
+++ b/content/docs/main/explanations/how-maintenance-works/_index.md
@@ -65,7 +65,7 @@ When you run `plakar rm`, Plakar records a new state where that snapshot no long
 
 Running `plakar maintenance` is what actually reclaims storage. During a maintenance run, Plakar scans the store and identifies chunks that are no longer referenced by any snapshot. Those chunks are marked as candidates for deletion and held for a grace period before removal.
 
-Maintenance can be automated using the Plakar scheduler. See [Scheduling tasks](../../guides/scheduling) for details.
+Maintenance can be automated using the Plakar scheduler. See [Scheduling tasks](../../guides/setup-scheduler-daily-backups) for details.
 
 ### The grace period
 

--- a/content/docs/main/quickstart/synchronize-copies.md
+++ b/content/docs/main/quickstart/synchronize-copies.md
@@ -19,7 +19,7 @@ This guide assumes that:
 
 ## Why create multiple copies?
 
-Keeping multiple backup copies dramatically reduces the risk of total data loss by **turning a realistic single-site failure into an extremely unlikely event when data is replicated across independent locations** (see the [Why should you keep several copies of your backups?](../guides/why-several-copies/_index.md) guide).
+Keeping multiple backup copies dramatically reduces the risk of total data loss by **turning a realistic single-site failure into an extremely unlikely event when data is replicated across independent locations** (see the [Why should you keep several copies of your backups?](../explanations/why-several-copies/_index.md) guide).
 
 **Plakar** is designed to make it easy to synchronize a Kloset Store to another location.
 


### PR DESCRIPTION
Fix two broken links in the documentation:

- [Synchronize multiple copies](https://www.plakar.io/docs/v1.0.6/quickstart/synchronize-copies/): link to `why-several-copies` pointed to `guides/` instead of `explanations/`
- [How Maintenance Works ](https://www.plakar.io/docs/v1.0.6/explanations/how-maintenance-works/): link to scheduling guide pointed to non-existent `guides/scheduling`, fixed to `guides/setup-scheduler-daily-backups`