### PR TITLE
docs: fix typos across integrations and documentation

### DIFF
--- a/content/docs/main/explanations/how-plakar-works/index.md
+++ b/content/docs/main/explanations/how-plakar-works/index.md
@@ -51,7 +51,7 @@ Now, let's understand why CDC is important. In our video example, what would hap
 
 CDC stands for "Content Defined Chunking", and it is a technique that uses the content of the file to determine the size of the chunks. This means that if you add a single byte to the middle of a file, only the chunk containing that byte will be considered as changed, and only that chunk will be stored again. The rest of the file will remain unchanged. The "single byte change" in the middle of the file is obviously an example, and the same applies if you make larger changes to the file, such as adding or removing a few lines of text in a text file, or changing a few pixels in an image file.
 
-To get a better understanding of how CDC works and to know more about go-cdc-chunker, the library we open-sourced to implement CDC in Kloset, read the [go-cdc-chunker blog post](https://www.plakar.io/posts/2025-07-11/introducing-go-cdc-chunkers-chunk-and-deduplicate-everything/).
+To get a better understanding of how CDC works and to know more about go-cdc-chunkers, the library we open-sourced to implement CDC in Kloset, read the [go-cdc-chunker blog post](https://www.plakar.io/posts/2025-07-11/introducing-go-cdc-chunkers-chunk-and-deduplicate-everything/).
 
 ## Compression
 

--- a/content/docs/main/guides/creating-a-custom-connector/_index.md
+++ b/content/docs/main/guides/creating-a-custom-connector/_index.md
@@ -112,7 +112,7 @@ func (f *testConnector) Import(ctx context.Context, records chan<- *connectors.R
 }
 ```
 
-{{% notice style="warning" title="Writting to console" expanded="true" %}}
+{{% notice style="warning" title="Writing to console" expanded="true" %}}
 Never write to `os.Stdout`. Plakar communicates with the plugin over gRPC through stdin/stdout — any writes there corrupt the stream. Use `os.Stderr` for debug output instead.
 {{% /notice %}}
 

--- a/content/docs/main/guides/exoscale/exoscale-compute-as-a-dedicated-backup-server/_index.md
+++ b/content/docs/main/guides/exoscale/exoscale-compute-as-a-dedicated-backup-server/_index.md
@@ -55,11 +55,11 @@ linkStyle default stroke:#94a3b8,stroke-width:2px,stroke-dasharray:5 5
 
 ### Create bucket in Exoscale Portal
 1. In the Exoscale portal, navigate to **Storage**
-3. Click **Add** to create a new bucket
-4. Configure:
+2. Click **Add** to create a new bucket
+3. Configure:
     - Zone: Select region (note the name, it'll be used to connect to the container e.g `ch-dk-2`)
     - Name: `plakar-backups` (must be globally unique)
-5. Click **Add**
+4. Click **Add**
 
 ![Create Storage Bucket](./images/setup-storage-1.png)
 

--- a/content/docs/main/guides/exoscale/exoscale-compute-as-a-dedicated-backup-server/_index.md
+++ b/content/docs/main/guides/exoscale/exoscale-compute-as-a-dedicated-backup-server/_index.md
@@ -65,7 +65,7 @@ linkStyle default stroke:#94a3b8,stroke-width:2px,stroke-dasharray:5 5
 
 ### Generate IAM API Keys
 1. In the Exoscale portal, navigate to **IAM** → **Keys**
-2. Click on **Add** to create new API keys then provide and role then click **Create**.
+2. Click on **Add** to create new API keys, then provide a name and role, then click **Create**.
 3. Copy the key and secret to a secure environment (you cannot see the secret once you leave the page)
 
 ![Create IAM API Key](./images/setup-iam-1.png)

--- a/content/docs/main/guides/exoscale/exoscale-compute-as-a-dedicated-backup-server/_index.md
+++ b/content/docs/main/guides/exoscale/exoscale-compute-as-a-dedicated-backup-server/_index.md
@@ -157,7 +157,7 @@ Configuring the passphrase in the store enables automated backups without prompt
 
 ### Initialize Kloset Store
 ```bash
-plakar at "exoscale-sos-backups" create
+plakar at "@exoscale-sos-backups" create
 ```
 
 ## Configure SSH Access to Source Servers

--- a/content/docs/main/integrations/onedrive/index.md
+++ b/content/docs/main/integrations/onedrive/index.md
@@ -246,7 +246,7 @@ rclone config show | plakar source import -rclone mydrive
 # Back up the remote directory to the Kloset store on the filesystem
 $ plakar at /var/backups backup "@mydrive"
 
-# Or back up the remote directory to a Kloset store configure with "plakar store add"
+# Or back up the remote directory to a Kloset store configured with "plakar store add"
 $ plakar at "@store" backup "@mydrive"
 ```
 

--- a/content/docs/main/integrations/onedrive/index.md
+++ b/content/docs/main/integrations/onedrive/index.md
@@ -115,7 +115,7 @@ For Rclone v1.72.1, the configuration flow is as follows:
 2. Name the remote (e.g., `mydrive`).
 3. Enter the number corresponding to "Microsoft OneDrive" from the list of supported storage providers.
 4. Leave client_id and client_secret empty to use Rclone's defaults, or provide your own if you have them.
-5. Select your region (usually "Microsoft Cloud Global")  .
+5. Select your region (usually "Microsoft Cloud Global").
 6. Enter service principal's tenant ID if applicable, or leave empty.
 7. Stay with the current settings, and do not edit advanced config.
 8. Choose to open the browser for authentication.

--- a/content/docs/main/integrations/sftp/index.md
+++ b/content/docs/main/integrations/sftp/index.md
@@ -267,9 +267,9 @@ $ plakar at "@sftp_store" restore -to "@sftp_dst" <snapshot_id>
 
 These options can be set when configuring the destination connector with `plakar destination add` or `plakar destination set`:
 
-| Option     | Purpose                                                             |
-| ---------- | ------------------------------------------------------------------- |
-| `location` | `sftp://[user@]host[:port]/path` of the remote directory to back up |
+| Option     | Purpose                                                              |
+| ---------- | -------------------------------------------------------------------- |
+| `location` | `sftp://[user@]host[:port]/path` of the remote directory to restore to |
 
 ---
 

--- a/content/docs/main/quickstart/installation.md
+++ b/content/docs/main/quickstart/installation.md
@@ -8,7 +8,7 @@ summary: Install Plakar and verify your installation.
 Several installation methods are available depending on your operating system. Choose the method that best suits your environment.
 
 {{% notice style="info" title="Developer Version" expanded="true" %}}
-This the developer version of Plakar and it can only be installed from source. Only stable versions have distributed assests that can be installed using other OS specific methods
+This is the developer version of Plakar and it can only be installed from source. Only stable versions have distributed assets that can be installed using other OS specific methods
 {{% /notice %}}
 
 To build Plakar from source. You will need:

--- a/content/integrations/caldav/index.md
+++ b/content/integrations/caldav/index.md
@@ -9,7 +9,7 @@ description: >
 technology_title: "CalDAV is a universal calendar infrastructure"
 
 technology_description: >
-  CalDAV (Calendaring Extensions to WebDAV) is an open standard protocol for accessing and managing calendar data on remote servers. It's supported by major providers including Nextcloud, Fastmail, iCloud, and Google Workspace (via gateways). CalDAV provides reliable synchronization across devices, but fails to provide immutability, versioning, or protection against accidental deletion of data or corruption. Plakar can backup and restore your calendar data from any CalDAV server, it also preserves complete event history and metadata.
+  CalDAV (Calendaring Extensions to WebDAV) is an open standard protocol for accessing and managing calendar data on remote servers. It's supported by major providers including Nextcloud, Fastmail, iCloud, and Google Workspace (via gateways). CalDAV provides reliable synchronization across devices, but fails to provide immutability, versioning, or protection against accidental deletion of data or corruption. Plakar can backup and restore your calendar data from any CalDAV server. It also preserves complete event history and metadata.
 
 categories:
   - source connector

--- a/content/integrations/fs/index.md
+++ b/content/integrations/fs/index.md
@@ -13,7 +13,7 @@ technology_description: >
 
   Accidental deletions, disk failures, malware, and human error can permanently destroy data in seconds.
 
-  Plakar makes filesystems verifiable, immutable backup sources by creating encrypted point-in-time snapshots snapshots that provide a reliable recovery point in case of data loss or corruption.
+  Plakar makes filesystems verifiable, immutable backup sources by creating encrypted point-in-time snapshots that provide a reliable recovery point in case of data loss or corruption.
 
 categories:
 - source connector

--- a/content/integrations/s3/index.md
+++ b/content/integrations/s3/index.md
@@ -28,7 +28,7 @@ tags:
   - Scality
   - Wasabi
   - Scaleway
-  - Blackblaze
+  - Backblaze
   - OVH
   - Infomaniak
 

--- a/content/integrations/s3/index.md
+++ b/content/integrations/s3/index.md
@@ -10,7 +10,7 @@ technology_title: S3 is the industry standard, but it isn't bulletproof
 
 technology_description: >
   S3-compatible storage is the backbone of the modern web, powering everything from media assets and log archives to mission-critical databases and AI training sets. While S3 offers high durability, it remains vulnerable to logical failures: accidental overwrites, compromised credentials, or misconfigured lifecycle policies. Plakar transforms S3 into a truly resilient backup ecosystem, adding a layer of 
-  cryptographic integrity, global deduplication, an independent immutability that standard object storage lacks.
+  cryptographic integrity, global deduplication, and independent immutability that standard object storage lacks.
 
 categories:
   - source connector

--- a/content/integrations/sftp/index.md
+++ b/content/integrations/sftp/index.md
@@ -62,7 +62,7 @@ resource_type: file-transfer
 ## Why protecting SFTP matters
 SFTP is a standard for secure file transfers across Linux servers, BSD hosts, and NAS devices like Synology and QNAP. However, secure transfer is not the same as a backup strategy.
 
-While SFTP secures the data in transit, it does not protect the data once it arrives to where you want to store it. Standard SFTP setups face several risks:
+While SFTP secures the data in transit, it does not protect the data once it arrives where you want to store it. Standard SFTP setups face several risks:
 - **Lack of Versioning**: Files can be overwritten or deleted immediately after upload.
 - **No Immutability**: There are no permanent snapshots to revert to if a file is corrupted.
 - **Operational Risk**: Manual transfers or custom scripts are error-prone and difficult to audit.

--- a/content/integrations/stdio/index.md
+++ b/content/integrations/stdio/index.md
@@ -48,7 +48,7 @@ resource_type: stdio
 ---
 
 ## Why use Streams instead of Files?
-Plakar’s Stdio integration can back up any data stream provided via stdin like database dumps, system logs, command output or custom scripts. Unlike workflows that first create an intermediate files, streaming data directly avoids several challenges:
+Plakar’s Stdio integration can back up any data stream provided via stdin like database dumps, system logs, command output or custom scripts. Unlike workflows that first create intermediate files, streaming data directly avoids several challenges:
 - **Storage Waste**: You need enough free space to hold the uncompressed export before it even gets to your backup tool.
 - **Security Risks**: Temporary files often sit on your disk unencrypted while waiting to be backed up.
 - **Complexity**: You have to manage the creation and deletion of these intermediate files.


### PR DESCRIPTION
Fix typos, spelling errors, and grammar issues found across the site.

**Integration pages**
- `fs`: remove duplicate word "snapshots snapshots"
- `s3`: fix "Blackblaze" -> "Backblaze", fix "an" -> "and" in description
- `stdio`: remove erroneous article "an intermediate files"
- `caldav`: fix comma splice in description
- `sftp`: fix "arrives to where" -> "arrives where"

**Documentation**
- `installation`: fix "This the" -> "This is the", "assests" -> "assets"
- `creating-a-custom-connector`: fix "Writting" -> "Writing"
- `exoscale guide`: fix numbered list skipping step 2, fix broken sentence in IAM key creation, add missing `@` prefix on store name
- `onedrive`: remove extra spaces before period, fix "configure" -> "configured"
- `how-plakar-works`: fix library name "go-cdc-chunker" -> "go-cdc-chunkers"
- `sftp integration`: fix destination connector description ("to back up" -> "to restore to")