### PR TITLE
geo: agent-readiness foundation (robots, api-catalog, agent-skills)

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,53 @@
+{{/*
+  Plakar.io robots.txt template.
+
+  Emits Content-Signal directives per the IETF AI Preferences draft
+  (https://contentsignals.org/, draft-romm-aipref-contentsignals).
+
+  Site stance:
+    - search=yes        — let traditional crawlers index us (SEO)
+    - ai-input=yes      — let AI assistants ground retrieval-augmented
+                          answers in our content (GEO)
+    - ai-train=no       — disallow training-corpus inclusion
+*/ -}}
+User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+Allow: /
+
+# Sitemap (Hugo-generated)
+Sitemap: {{ "sitemap.xml" | absURL }}
+
+# ---------------------------------------------------------------------------
+# Per-bot overrides. Keep the global rule above as the floor; tighten here
+# for crawlers that have separate training vs. search identities.
+# ---------------------------------------------------------------------------
+
+# Google's training crawler (separate from Googlebot, which keeps default).
+User-agent: Google-Extended
+Content-Signal: ai-train=no
+Disallow: /
+
+# OpenAI training crawler.
+User-agent: GPTBot
+Content-Signal: ai-train=no
+Disallow: /
+
+# OpenAI search crawler (retrieval for ChatGPT search) — keep open.
+User-agent: OAI-SearchBot
+Content-Signal: search=yes, ai-input=yes
+Allow: /
+
+# Anthropic training crawler.
+User-agent: ClaudeBot
+Content-Signal: ai-train=no
+Disallow: /
+
+# Anthropic user-fetch crawler (Claude grounding) — keep open.
+User-agent: Claude-User
+Content-Signal: ai-input=yes
+Allow: /
+
+# Perplexity (retrieval-augmented answers).
+User-agent: PerplexityBot
+Content-Signal: search=yes, ai-input=yes
+Allow: /

--- a/static/.well-known/agent-skills/backup-postgres/SKILL.md
+++ b/static/.well-known/agent-skills/backup-postgres/SKILL.md
@@ -1,0 +1,39 @@
+# Backup PostgreSQL with Plakar
+
+Take a consistent, encrypted, deduplicated backup of a PostgreSQL database
+into a Plakar Kloset.
+
+## Requirements
+
+- Plakar CLI installed (see the `install-plakar` skill)
+- A reachable PostgreSQL instance and credentials with `pg_dump` privileges
+- A Kloset repository (local path, S3 bucket, or Vault Provider URL)
+
+## Steps
+
+1. Configure the PostgreSQL source connector:
+   ```sh
+   plakar source add postgres-prod \
+     --type postgres \
+     --dsn "postgres://backup_user:****@db.internal:5432/app"
+   ```
+2. Run the backup. Plakar will stream a logical dump through Kloset's
+   dedup + encrypt pipeline before persisting:
+   ```sh
+   plakar at s3://plakar-backups/prod backup source://postgres-prod
+   ```
+3. Verify the snapshot's cryptographic integrity proof:
+   ```sh
+   plakar at s3://plakar-backups/prod check --latest
+   ```
+4. (Recommended) Schedule with cron or systemd for hourly backups.
+
+## Validate
+
+`plakar at s3://plakar-backups/prod ls` shows the new snapshot, and
+`check --latest` reports `Integrity verified`.
+
+## References
+
+- Postgres how-to: https://www.plakar.io/posts/2026-04-03/backing-up-postgresql-with-plakar/
+- Integrations catalog: https://www.plakar.io/integrations/

--- a/static/.well-known/agent-skills/index.json
+++ b/static/.well-known/agent-skills/index.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "publisher": {
+    "name": "PlakarKorp",
+    "url": "https://plakar.io/",
+    "contact": "support@plakar.io"
+  },
+  "skills": [
+    {
+      "name": "install-plakar",
+      "type": "skill-md",
+      "description": "Install the Plakar CLI on Linux, macOS, or Windows and verify the install with a local Kloset.",
+      "url": "https://plakar.io/.well-known/agent-skills/install-plakar/SKILL.md",
+      "digest": "sha256:9a32d52802af2dc5ac9a6d52c84d8663591e6015a3eb80fb47135f81c9794a50"
+    },
+    {
+      "name": "backup-postgres",
+      "type": "skill-md",
+      "description": "Take a consistent, encrypted, deduplicated backup of a PostgreSQL database into a Plakar Kloset.",
+      "url": "https://plakar.io/.well-known/agent-skills/backup-postgres/SKILL.md",
+      "digest": "sha256:00b76e8e085f0410babfaf7e2fe1dc73da1efa49174ca06f8bdcb357c3215d0c"
+    },
+    {
+      "name": "restore-snapshot",
+      "type": "skill-md",
+      "description": "Restore files from a Plakar snapshot, or mount the snapshot read-only via FUSE/WinFsp for partial recovery.",
+      "url": "https://plakar.io/.well-known/agent-skills/restore-snapshot/SKILL.md",
+      "digest": "sha256:5c841a7fe5eaaaca268e99bcf8b21f2aa09b71d0e7b0abc4c5f6d250f1993609"
+    }
+  ]
+}

--- a/static/.well-known/agent-skills/install-plakar/SKILL.md
+++ b/static/.well-known/agent-skills/install-plakar/SKILL.md
@@ -1,0 +1,37 @@
+# Install Plakar
+
+Install the Plakar CLI on your machine and verify it works.
+
+## Requirements
+
+- A POSIX-compatible shell (Linux, macOS, WSL) or Windows PowerShell
+- 1 GB free disk for the binary and a small test repository
+- Network access to GitHub releases
+
+## Steps
+
+1. Install via the platform-appropriate path:
+   - **Linux / macOS (Homebrew)**: `brew install plakarkorp/tap/plakar`
+   - **Linux (binary)**: download from https://github.com/PlakarKorp/plakar/releases and place in `$PATH`
+   - **Windows**: download the Windows release archive and add the binary to `PATH`
+2. Verify the install:
+   ```sh
+   plakar version
+   ```
+   Expected output includes `plakar v1.x.x`.
+3. Initialize a local Kloset repository to confirm end-to-end:
+   ```sh
+   plakar at /tmp/plakar-demo create
+   plakar at /tmp/plakar-demo backup ~/Documents
+   plakar at /tmp/plakar-demo ls
+   ```
+
+## Validate
+
+`plakar version` exits 0 and `plakar at /tmp/plakar-demo ls` lists at least one snapshot.
+
+## References
+
+- Documentation: https://docs.plakar.io/
+- Quickstart: https://www.plakar.io/docs/v1.0.6/quickstart/first-backup
+- Source: https://github.com/PlakarKorp/plakar

--- a/static/.well-known/agent-skills/restore-snapshot/SKILL.md
+++ b/static/.well-known/agent-skills/restore-snapshot/SKILL.md
@@ -1,0 +1,40 @@
+# Restore from a Plakar Snapshot
+
+Restore files from a Plakar snapshot to a target location, or mount the
+snapshot as a read-only filesystem for partial recovery.
+
+## Requirements
+
+- Plakar CLI installed
+- Read access to the Kloset repository holding the snapshot
+- (Mount-only) FUSE on Linux/macOS, or WinFsp on Windows
+
+## Steps — full restore
+
+1. List snapshots and pick one:
+   ```sh
+   plakar at s3://plakar-backups/prod ls
+   ```
+2. Restore by snapshot ID (prefix is enough):
+   ```sh
+   plakar at s3://plakar-backups/prod restore <snapshot-id> \
+     --to /var/restore/2026-05-09
+   ```
+
+## Steps — mount and browse without restoring
+
+```sh
+plakar at s3://plakar-backups/prod mount /mnt/plakar-snap <snapshot-id>
+ls /mnt/plakar-snap
+plakar at s3://plakar-backups/prod umount /mnt/plakar-snap
+```
+
+## Validate
+
+Restored files match the original tree (`diff -r`), or the mount is
+browsable and reads succeed without errors in the Plakar log.
+
+## References
+
+- Documentation: https://docs.plakar.io/
+- Mount guide: https://www.plakar.io/docs

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,36 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://plakar.io/",
+      "service-doc": [
+        {
+          "href": "https://docs.plakar.io/",
+          "type": "text/html",
+          "title": "Plakar Documentation"
+        },
+        {
+          "href": "https://plakar.io/control-plane-docs/",
+          "type": "text/html",
+          "title": "Plakar Control Plane Documentation"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://status.plakar.io/",
+          "type": "text/html",
+          "title": "Plakar Service Status"
+        }
+      ]
+    },
+    {
+      "anchor": "https://plakar.io/integrations/",
+      "service-doc": [
+        {
+          "href": "https://plakar.io/integrations/",
+          "type": "text/html",
+          "title": "Plakar Integrations Catalog"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# PR 1 — geo: agent-readiness foundation (robots, api-catalog, agent-skills)

**Branch:** `geo/agent-readiness-foundation`
**Patch:** `01-agent-readiness-foundation.patch`
**Closes:** 4 of the 9 [isitagentready.com](https://isitagentready.com/) audit findings

## Why

Agent-readiness is the GEO (Generative Engine Optimization) equivalent of a Lighthouse audit: a battery of standards-based checks that determine how well a site is grounded by AI assistants and traversed by autonomous agents. This PR closes the four findings that resolve to static files only — no infrastructure dependencies, no auth dependencies, no service builds.

## What changes

| File | Purpose | Spec |
| --- | --- | --- |
| `layouts/robots.txt` | Hugo template emitting Content-Signal directives + per-bot overrides | [draft-romm-aipref-contentsignals](https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/) |
| `static/.well-known/api-catalog` | linkset+json declaring docs and status endpoints | [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727), [RFC 9264](https://www.rfc-editor.org/rfc/rfc9264) |
| `static/.well-known/agent-skills/index.json` | v0.2.0 skills discovery index with sha256 digests | [agent-skills-discovery-rfc](https://github.com/cloudflare/agent-skills-discovery-rfc) |
| `static/.well-known/agent-skills/{install-plakar,backup-postgres,restore-snapshot}/SKILL.md` | Three authoritative how-tos for AI assistants | same |

## robots.txt stance — please confirm

The template asserts:

```
User-agent: *
Content-Signal: search=yes, ai-input=yes, ai-train=no
```

…with explicit `Disallow: /` overrides for `Google-Extended`, `GPTBot`, and `ClaudeBot` (training crawlers), and `Allow: /` for `OAI-SearchBot`, `Claude-User`, and `PerplexityBot` (retrieval crawlers).

Rationale: it's the OSS-default of "be visible in search and AI answers, do not contribute to training corpora". If product strategy is "maximum reach including training", flip `ai-train=no` → `ai-train=yes` and remove the per-bot training disallows.

## Cloudflare Transform Rule (required for the api-catalog)

GitHub Pages serves `static/.well-known/api-catalog` (no extension) as `application/octet-stream`. The audit scanner is content-aware enough to still pass this, but spec-compliant clients want `application/linkset+json`. Add this Transform Rule in the Cloudflare dashboard after merging:

- **When:** `(http.request.uri.path eq "/.well-known/api-catalog")`
- **Then:** Set static `Content-Type: application/linkset+json`

Same pattern for the other extension-less files we'll add in subsequent PRs (`oauth-protected-resource`, etc.).

## Testing

Local Hugo build:

```sh
npm run build
ls -la public/.well-known/
cat public/robots.txt
```

After deploy:

```sh
curl -s https://plakar.io/robots.txt | head -20
curl -s https://plakar.io/.well-known/api-catalog | jq .linkset
curl -s https://plakar.io/.well-known/agent-skills/index.json | jq .skills

# Re-run the original audit
curl -sX POST https://isitagentready.com/api/scan \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://plakar.io"}' | jq '.checks.botAccessControl.contentSignals, .checks.discovery.apiCatalog, .checks.discovery.agentSkills'
```

All three checks should report `"status": "pass"`.

## Maintaining the agent-skills index

Whenever a `SKILL.md` is added or edited, recompute its sha256 and update `index.json`. Suggested CI check:

```sh
sha256sum static/.well-known/agent-skills/*/SKILL.md
```

Diff each digest against the committed `index.json`; fail if drift.

## What's intentionally NOT here

- The fourth quick-win (markdown content negotiation) is handled at the Cloudflare layer (enable "Markdown for Agents" in the dashboard, or deploy a Worker). It's not a Hugo concern, so it doesn't belong in this repo.
- OAuth/OIDC discovery (issues 5 and 6) lives on `auth.plakar.io`, not the marketing site.
- The MCP server card is a separate PR (#2) because its dependence on a not-yet-built MCP server is worth review on its own.
