### PR TITLE
fix nil pointer crash when post has no featured image

### DIFF
--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -27,12 +27,13 @@
 {{ with index $featured 0 }}
   {{ $image := or (.Resources.GetMatch "featured.webp") (index (.Resources.Match "featured.*") 0) }}
   {{ if not $image }}
-    {{ $image = resources.Get "img/placeholder-400x254.png" }}
+    {{ with resources.Get "img/placeholder-400x254.png" }}{{ $image = . }}{{ end }}
   {{ end }}
 
   <section class="section-light-2 py-7 px-4">
     <div class="max-w-350 mx-auto flex flex-col xl:flex-row items-center xl:items-stretch gap-6">
 
+      {{ if $image }}
       <!-- Image -->
       <div class="w-full max-w-lg xl:max-w-none xl:w-1/2 shrink-0 rounded-lg bg-neutral-50 border border-neutral-300">
         <div class="w-full h-7 px-4 flex items-center gap-2 border-b border-neutral-200">
@@ -44,6 +45,7 @@
           <img src="{{ $image.RelPermalink }}" alt="Article preview" class="w-full h-auto object-cover rounded-sm">
         </div>
       </div>
+      {{ end }}
 
       <!-- Content -->
       <div class="w-full max-w-lg xl:max-w-none bg-neutral-100 flex flex-1 flex-col gap-4 items-start justify-center px-4 xl:px-8 py-4 rounded-lg">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -3,7 +3,7 @@
 
 {{ $image := or (.Resources.GetMatch "featured.webp") (index (.Resources.Match "featured.*") 0) }}
 {{ if not $image }}
-  {{ $image = resources.Get "img/placeholder-1600x1200.png" }}
+  {{ with resources.Get "img/placeholder-1600x1200.png" }}{{ $image = . }}{{ end }}
 {{ end }}
 
 <!-- Hero -->
@@ -35,6 +35,7 @@
   </div>
 </section>
 
+{{ if $image }}
 <!-- Featured image -->
 <section class="section-light-2 grid-background">
   <div class="bg-gradient-section-light-1 px-4 py-2">
@@ -54,6 +55,7 @@
     </div>
   </div>
 </section>
+{{ end }}
 
 <!-- Article -->
 <section class="section-light-1 px-4 py-7">


### PR DESCRIPTION
Guard $image usage with {{ if $image }} so posts without a featured.* resource don't crash the template. Also use {{ with }} for the placeholder fallback so a missing placeholder file is silently skipped rather than returning nil and crashing downstream.