### PR TITLE
fix post-card.html using absolute Permalink instead of RelPermalink

### DIFF
--- a/layouts/partials/posts/post-card.html
+++ b/layouts/partials/posts/post-card.html
@@ -1,7 +1,7 @@
 {{ $p := . }}
 {{ $image := or ($p.Resources.GetMatch "featured.webp") (index ($p.Resources.Match "featured.*") 0) }}
 
-<a href="{{ $p.Permalink }}" data-category="{{ $p.Params.category }}" class="group/card flex flex-col rounded-lg border border-neutral-200 bg-neutral-50 shadow-xl outline-8 outline-neutral-400/20 hover:shadow-none transition-shadow duration-300 no-underline overflow-hidden">
+<a href="{{ $p.RelPermalink }}" data-category="{{ $p.Params.category }}" class="group/card flex flex-col rounded-lg border border-neutral-200 bg-neutral-50 shadow-xl outline-8 outline-neutral-400/20 hover:shadow-none transition-shadow duration-300 no-underline overflow-hidden">
   <div class="w-full p-4 aspect-video overflow-hidden">
     <img src="{{ $image.RelPermalink }}" alt="{{ $p.Title }}" class="w-full rounded-md h-full object-cover">
   </div>


### PR DESCRIPTION
Clicking post cards redirected to the production domain locally because the card anchor used $p.Permalink (absolute URL) instead of $p.RelPermalink (root-relative path).