### PR TITLE
add series navigation to post sidebar

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -61,6 +61,7 @@
 
     <!-- TOC sidebar -->
     <aside class="hidden xl:block xl:sticky xl:top-28 w-70 shrink-0">
+      {{ partial "series/series.html" . }}
       {{ partial "docs/toc.html" . }}
       {{ partial "posts/toc-share.html" . }}
     </aside>


### PR DESCRIPTION
Render the Blowfish series/series.html partial in the sticky sidebar above the TOC. It lists all articles in the series sorted by series_order, with the current article highlighted.

Note it's not used yet, but it will be very soon.