### PR TITLE
Hide category filter buttons for unused categories

### DIFF
--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -92,6 +92,18 @@
 {{ end }}
 
 <!-- Category filter -->
+{{ $categoryLabels := dict "announcement" "Announcement" "release-note" "Release Notes" "community" "Community" "insights" "Insights" "technology" "Technology" }}
+{{ $categoryOrder := slice "announcement" "release-note" "community" "insights" "technology" }}
+{{ $usedCategories := slice }}
+{{ range (where .Pages "Params.hidden" "ne" true) }}
+  {{ with .Params.category }}
+    {{ if not (in $usedCategories .) }}
+      {{ $usedCategories = $usedCategories | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $hasMultipleCategories := gt (len $usedCategories) 1 }}
+{{ if $hasMultipleCategories }}
 <section class="section-light-2 px-4 pb-6 pt-10">
   <div class="max-w-350 mx-auto flex justify-center">
     <div class="relative posts-filter-dropdown w-full sm:hidden">
@@ -103,23 +115,24 @@
       </button>
       <div class="posts-filter-dropdown-menu hidden absolute top-full mt-1 w-full bg-neutral-50 border border-neutral-200 rounded-lg z-50 overflow-hidden shadow-lg">
         <a data-filter="all" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">All Posts</a>
-        <a data-filter="announcement" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">Announcement</a>
-        <a data-filter="release-note" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">Release Notes</a>
-        <a data-filter="community" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">Community</a>
-        <a data-filter="insights" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">Insights</a>
-        <a data-filter="technology" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">Technology</a>
+        {{ range $categoryOrder }}
+          {{ if in $usedCategories . }}
+            <a data-filter="{{ . }}" class="filter-dropdown-option block px-3 py-2 text-sm text-neutral-700 hover:bg-neutral-100 hover:text-primary-500 cursor-pointer">{{ index $categoryLabels . }}</a>
+          {{ end }}
+        {{ end }}
       </div>
     </div>
     <div class="hidden sm:inline-flex items-center gap-1 bg-neutral-50 rounded-xl p-2" id="posts-filter">
       <a data-filter="all" class="filter-btn px-4 py-3 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">All Posts</a>
-      <a data-filter="announcement" class="filter-btn px-2 py-4 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">Announcement</a>
-      <a data-filter="release-note" class="filter-btn px-2 py-4 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">Release Notes</a>
-      <a data-filter="community" class="filter-btn px-2 py-4 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">Community</a>
-      <a data-filter="insights" class="filter-btn px-2 py-4 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">Insights</a>
-      <a data-filter="technology" class="filter-btn px-2 py-4 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">Technology</a>
+      {{ range $categoryOrder }}
+        {{ if in $usedCategories . }}
+          <a data-filter="{{ . }}" class="filter-btn px-2 py-4 rounded-lg text-sm cursor-pointer font-medium transition-all duration-150 text-neutral-700">{{ index $categoryLabels . }}</a>
+        {{ end }}
+      {{ end }}
     </div>
   </div>
 </section>
+{{ end }}
 
 <!-- Posts grid -->
 <section id="posts-grid" class="section-light-2 px-4 py-12">


### PR DESCRIPTION
Only render filter buttons for categories that have at least one visible post, and hide the entire filter section when posts share a single category.