### PR TITLE
fix: update link for creating the first backup in quickstart overview

### DIFF
--- a/content/docs/community/main/quickstart/overview.md
+++ b/content/docs/community/main/quickstart/overview.md
@@ -29,7 +29,7 @@ backups, Plakar makes it straightforward.
 ## Getting Started
 
 - [Plakar Installation Guide](./installation)
-- [Create your first backup](./quickstart)
+- [Create your first backup](./first-backup)
 
 ## Core Concepts
 

--- a/content/docs/community/v1.0.6/quickstart/overview.md
+++ b/content/docs/community/v1.0.6/quickstart/overview.md
@@ -29,7 +29,7 @@ backups, Plakar makes it straightforward.
 ## Getting Started
 
 - [Plakar Installation Guide](./installation)
-- [Create your first backup](./quickstart)
+- [Create your first backup](./first-backup)
 
 ## Core Concepts
 

--- a/content/docs/community/v1.1.0/quickstart/overview.md
+++ b/content/docs/community/v1.1.0/quickstart/overview.md
@@ -29,7 +29,7 @@ backups, Plakar makes it straightforward.
 ## Getting Started
 
 - [Plakar Installation Guide](./installation)
-- [Create your first backup](./quickstart)
+- [Create your first backup](./first-backup)
 
 ## Core Concepts
 


### PR DESCRIPTION
A small fix for redirect to first-backup page when clicking on `Create your first backup` instead of 404