### PR TITLE
chore: update shell-quote to resolve npm audit vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,9 +1607,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

This updates the `shell-quote` dependency in `package-lock.json` from `1.8.3` to `1.10.0`.

After the update, `npm audit` reports **0 vulnerabilities**.

## Testing

```bash
npm install
npm audit
```

**Result**

```text
found 0 vulnerabilities
```

Screen recording:

https://github.com/user-attachments/assets/0d414bc2-4c54-475c-830b-34967de1817e

