### PR TITLE
analytics: dedupe GA4 into GTM and remove broken Axeptio consent bridge

### DIFF
--- a/assets/js/main/gtm.js
+++ b/assets/js/main/gtm.js
@@ -9,6 +9,10 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!id) return;
 
   // Google Consent Mode v2 defaults (must run before the GTM loader below).
+  // Consent *updates* are driven natively by Axeptio's Google Consent Mode v2
+  // integration (project vendor `google_consent_mode_v2`, googleConsentMode
+  // enabled in the Axeptio config) — it pushes gtag('consent','update',...) on
+  // the user's choice, so no custom _axcb bridge is needed here.
   window.dataLayer = window.dataLayer || [];
   function gtag() {
     dataLayer.push(arguments);
@@ -25,23 +29,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
   gtag("set", "url_passthrough", true);
   gtag("set", "ads_data_redaction", true);
-
-  // Bridge Axeptio consent choices -> Google Consent Mode.
-  // NOTE: the choice keys below (google_analytics, google_ads) must match the
-  // vendor identifiers configured in the Axeptio project.
-  window._axcb = window._axcb || [];
-  window._axcb.push(function (axeptio) {
-    axeptio.on("cookies:complete", function (choices) {
-      const analytics = choices.google_analytics ? "granted" : "denied";
-      const ads = choices.google_ads ? "granted" : "denied";
-      gtag("consent", "update", {
-        analytics_storage: analytics,
-        ad_storage: ads,
-        ad_user_data: ads,
-        ad_personalization: ads,
-      });
-    });
-  });
 
   (function (w, d, s, l, i) {
     w[l] = w[l] || [];

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -11,7 +11,10 @@ summaryLength = 0
 buildDrafts = false
 buildFuture = false
 enableEmoji = true
-googleAnalytics = "G-4EJ3HLL4HS"
+# Google Analytics (G-4EJ3HLL4HS) is loaded via the Google Tag Manager container
+# (GTM-T7VMM5VM) so there is a single, consent-gated GA4 path. Do not also set
+# `googleAnalytics` here — the theme would load GA4 a second time (double-counting)
+# and outside Consent Mode.
 
 [permalinks]
   [permalinks.page]


### PR DESCRIPTION
## Fix GA4 double-load and the broken Axeptio consent bridge

Follow-up to #330 (GTM install). Two analytics-correctness fixes, both confirmed by inspecting the **live** production site.

### 1. GA4 was loaded twice → keep a single, consent-gated path
On live `plakar.io`, GA4 `G-4EJ3HLL4HS` was loading **twice**:
- directly by the theme (`googleAnalytics` in `hugo.toml` → `analytics/ga.html`, in `<head>`, **outside** Consent Mode), and
- again inside the GTM container `GTM-T7VMM5VM`.

Verified in-browser: `document.querySelectorAll('script[src*="G-4EJ3HLL4HS"]').length === 1` **and** `window.google_tag_manager['G-4EJ3HLL4HS']` present → same property counted twice, and the theme's copy fired before any consent default.

**Fix:** remove `googleAnalytics` from `config/_default/hugo.toml`. GA4 keeps running through the GTM container (already configured there), so there's no data-collection gap — just one path instead of two, now behind Consent Mode.

### 2. The custom Axeptio consent bridge never matched → remove it
The `_axcb` bridge in `assets/js/main/gtm.js` mapped `choices.google_analytics` / `choices.google_ads`. Inspecting the live Axeptio SDK config, this project has **no such vendors** — its consent step is `google_consent_mode_v2_4jdkvs` (name `google_consent_mode_v2`), and `cookies[0].googleConsentMode.display === true`, i.e. **Axeptio's native Google Consent Mode v2 is enabled** and pushes `gtag('consent','update',...)` itself.

So the custom bridge was:
- **broken** — its keys are always `undefined` → it resolved every signal to `denied`, so analytics could never be granted through it; and
- **harmful** — on `cookies:complete` it could race Axeptio's native `granted` update and overwrite it back to `denied`.

**Fix:** delete the `_axcb` bridge and rely on Axeptio's native GCM integration. The `gtag('consent','default', … denied)` block is kept as the pre-consent safety net.

### Verified (production build)
- GTM container `#gtm-config` marker + `<noscript>` still render; consent default still set before the GTM loader.
- The theme's direct GA4 script/inline `gtag('config','G-4EJ3HLL4HS')` is **gone**.
- The compiled JS bundle no longer contains `_axcb`, `cookies:complete`, or `google_analytics`.

### Note
Consent updates now flow only through Axeptio's native GCM. Worth a quick QA in GTM Preview + GA4 DebugView: accept/decline on the Axeptio banner and confirm `analytics_storage` flips `denied`↔`granted`.
